### PR TITLE
Handling 302 errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,20 +810,19 @@ fn build_url(args: &Arguments) -> String {
 }
 
 async fn get(url: String) -> Result<String, surf::Error> {
-    let mut res = surf::get(url)
+    let mut res = surf::get(&url)
         .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36")
         .await?;
     let status = res.status();
     if status == 302 {
-        let location = res.header("Location").unwrap();
-        let location = location.as_str();
-        let mut res = surf::get(location)
+        // Retry
+        let mut res = surf::get(&url)
         .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36").await?;
         let status = res.status();
         if status != 200 {
             return Err(surf::Error::from_str(
                 status,
-                format!("GET request failed for {}", location),
+                format!("GET request failed for {}", url),
             ));
         }
         return res.body_string().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,19 +816,15 @@ async fn get(url: String) -> Result<String, surf::Error> {
     let status = res.status();
     if status == 302 {
         // Retry
-        const RETRY_COUNT: u8 = 5;
-        for idx in 0..RETRY_COUNT {
-            res = surf::get(&url)
+        let location = res.header("Location").unwrap().as_str();
+        res = surf::get(location)
             .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36").await?;
-            let status = res.status();
-            if status != 200 && idx == RETRY_COUNT - 1 {
-                return Err(surf::Error::from_str(
-                    status,
-                    format!("GET request failed for {}", url),
-                ));
-            } else if status == 200 {
-                break;
-            }
+        let status = res.status();
+        if status != 200 {
+            return Err(surf::Error::from_str(
+                status,
+                format!("GET request failed for {}", url),
+            ));
         }
     }
     res.body_string().await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,7 +821,10 @@ async fn get(url: String) -> Result<String, surf::Error> {
         .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36").await?;
         let status = res.status();
         if status != 200 {
-            return Err(surf::Error::from_str(status, "GET request failed"));
+            return Err(surf::Error::from_str(
+                status,
+                format!("GET request failed for {}", location),
+            ));
         }
         return res.body_string().await;
     }


### PR DESCRIPTION
Recently I have been recieving a lot of 302 page has been moved errors when using this crate in my application. I tried following the given location in the response but apparently it leads to further 302s. The best solution I found was to keep retrying until you get a response. If you want to tweak the retry count, you can do so freely.

Also I didnt change the version number as I thought you might like to customize things before publishing to crates. 

If there are any issues you dislike, please feel free to contact me.